### PR TITLE
Fix build errors on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ mod keyring;
 
 pub use keyring::*;
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use cryptex::macos::MacOsKeyRing as OsKeyRing;
 use cryptex::linux::LinuxOsKeyRing as OsKeyRing;
 
 #[cfg(target_os = "windows")]
-use cryptex::keyring::windows::WindowsOsKeyRing as OsKeyRing;
+use cryptex::windows::WindowsOsKeyRing as OsKeyRing;
 
 fn main() {
     let mut temp = App::new("Cryptex")


### PR DESCRIPTION
- Fix the `use` name consistently as linux and macos.
- Exclude test for `parse_peek_criteria_test` on windows